### PR TITLE
Select items

### DIFF
--- a/seasonal-bites/App.tsx
+++ b/seasonal-bites/App.tsx
@@ -5,7 +5,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Login from './app/screens/Login';
 import CreateAccount from './app/screens/CreateAccount';
 import Menu from './app/screens/Menu';
-import TileSelector from "./app/screens/Search";
+import Search from "./app/screens/Search";
 
 const Stack = createNativeStackNavigator();
 
@@ -30,8 +30,8 @@ export default function App() {
           options={{ headerShown: true }}
         />
          <Stack.Screen
-           name='TileSelector'
-           component={TileSelector}
+           name='Search'
+           component={Search}
            options={{ headerShown: false }} />
       </Stack.Navigator>
     </NavigationContainer>

--- a/seasonal-bites/App.tsx
+++ b/seasonal-bites/App.tsx
@@ -32,7 +32,7 @@ export default function App() {
          <Stack.Screen
            name='Search'
            component={Search}
-           options={{ headerShown: false }} />
+           options={{ headerShown: true }} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/seasonal-bites/app/screens/Menu.tsx
+++ b/seasonal-bites/app/screens/Menu.tsx
@@ -40,7 +40,7 @@ const Menu: React.FC = () => {
                 {/* Button to navigate to the search screen */}
                 <TouchableOpacity
                     style={styles.button}
-                    onPress={() => navigation.navigate('TileSelector')}
+                    onPress={() => navigation.navigate('Search')}
                 >
                     <Text style={styles.buttonText}>Search</Text>
                 </TouchableOpacity>

--- a/seasonal-bites/app/screens/Search.tsx
+++ b/seasonal-bites/app/screens/Search.tsx
@@ -93,6 +93,7 @@ const styles = StyleSheet.create({
         color: "#333",
       },      
   container: {
+    flex: 1,
     padding: 20,
     alignItems: "center",
   },

--- a/seasonal-bites/app/screens/Search.tsx
+++ b/seasonal-bites/app/screens/Search.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from "react";
-import { View, Button, Text, FlatList, TouchableOpacity, Image, StyleSheet } from "react-native";
+import React, { useState, useEffect, useRef } from "react";
+import { Animated, View, Button, Text, FlatList, TouchableOpacity, Image, StyleSheet } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { RootStackParamList } from "../navigation/types"; // Import the type from App.tsx
@@ -35,6 +35,9 @@ const Search: React.FC = () => {
 
   // Necessary for navigation
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+
+  // used as animation reference
+  const slideAnim = useRef(new Animated.Value(100)).current;
 
   /**
    * Here is where we query our Firestore database.
@@ -80,6 +83,21 @@ const Search: React.FC = () => {
         // toggles on
         : [...prevSelected, id] 
     );
+  };
+
+  // button slide animation
+  useEffect(() => {
+    Animated.timing(slideAnim, {
+      toValue: selectedTiles.length > 0 ? 0 : 100,
+      duration: 300,
+      useNativeDriver: true,
+    }).start();
+  }, [selectedTiles]);
+
+  // clears selected tile array
+  // TODO: have this send info to local storage
+  const clearSelection = () =>{
+    setSelectedTiles([]);
   };
 
   // Function to handle user logout
@@ -140,10 +158,12 @@ const Search: React.FC = () => {
         )}
       />
 
-      {/* Navigation Button */}
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate("Menu")}>
-        <Text style={styles.buttonText}>Return to Menu</Text>
-      </TouchableOpacity>
+            {/* Sliding Button */}
+            <Animated.View style={[styles.selectionButton, { transform: [{ translateY: slideAnim }] }]}>
+        <TouchableOpacity style={styles.button} onPress={clearSelection}>
+          <Text style={styles.buttonText}>Clear Selection ({selectedTiles.length})</Text>
+        </TouchableOpacity>
+      </Animated.View>
     </View>
   );
 };
@@ -203,6 +223,12 @@ const styles = StyleSheet.create({
     color: "#FFFFFF",
     fontSize: 16,
     fontWeight: "bold",
+  },
+  selectionButton: {
+    position: "absolute",
+    bottom: 20,
+    width: "80%",
+    alignSelf: "center",
   },
 });
 


### PR DESCRIPTION
This is largely  a refactor of the previous search page with some added functionality.

-  Search screen now relies on a Firestore database to build out the tiles, removed hardcoded list
- Tile images are now retrieved from Firestore urls
- Users can how select multiple tiles and have an array remember information about each
- Added sliding button that also tracks how many tiles are currently selected
- Added logout and navigation functionality consistent with other screens

Closes #5 